### PR TITLE
Update fasta

### DIFF
--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -79,7 +79,6 @@ impl DnaFastaParser {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
 
     #[test]
     fn test_empty_fasta() {


### PR DESCRIPTION
Updates to fasta parsing

- change `DNAFastaParser` to `DnaFastaParser`
- change `&mut R` to `R`
- handle `BufReader` internally, instead of passing a `BufReader` to parser