### PR TITLE
Allow empty spaces in DNA sequences

### DIFF
--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -1171,11 +1171,15 @@ mod tests {
     }
 
     #[test]
-    fn test_dna_invalid_dna_whitespace() {
-        assert_parse_err!(
+    fn test_dna_dna_whitespace() {
+        assert_parse!(
             ">Virus1\nAAAA \n",
             FastaParser::<DnaSequence>::strict(),
-            FastaParseError::ParseError(TranslationError::BadNucleotide(' '))
+            vec![FastaRecord {
+                header: "Virus1".to_string(),
+                contents: "AAAA".parse().unwrap(),
+                line_range: (1, 3),
+            }]
         );
     }
 

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -1153,6 +1153,29 @@ mod tests {
     }
 
     #[test]
+    fn test_dna_dna_whitespace() {
+        assert_parse!(
+            ">Virus1\nAAAA \n",
+            FastaParser::<DnaSequence>::strict(),
+            vec![FastaRecord {
+                header: "Virus1".to_string(),
+                contents: "AAAA".parse().unwrap(),
+                line_range: (1, 3),
+            }]
+        );
+
+        assert_parse!(
+            ">Virus1\n  AAAA\t\t\n",
+            FastaParser::<DnaSequence>::strict(),
+            vec![FastaRecord {
+                header: "Virus1".to_string(),
+                contents: "AAAA".parse().unwrap(),
+                line_range: (1, 3),
+            }]
+        );
+    }
+
+    #[test]
     fn test_dna_invalid_dna() {
         assert_parse_err!(
             ">Virus1\nAAAelephant",
@@ -1167,19 +1190,6 @@ mod tests {
             ">Virus1\nAAAA\n>Virus2\nAAAAelephant",
             FastaParser::<DnaSequence>::strict(),
             FastaParseError::ParseError(TranslationError::BadNucleotide('e'))
-        );
-    }
-
-    #[test]
-    fn test_dna_dna_whitespace() {
-        assert_parse!(
-            ">Virus1\nAAAA \n",
-            FastaParser::<DnaSequence>::strict(),
-            vec![FastaRecord {
-                header: "Virus1".to_string(),
-                contents: "AAAA".parse().unwrap(),
-                line_range: (1, 3),
-            }]
         );
     }
 

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -303,7 +303,7 @@ mod tests {
         for c in 0_u8..128 {
             let c = char::from(c);
             let r = DnaSequence::from_str(&String::from(c));
-            if "aAtTcCgGmMrRwWsSyYkKvVhHdDbBnN".chars().any(|x| x == c) {
+            if "aAtTcCgGmMrRwWsSyYkKvVhHdDbBnN ".chars().any(|x| x == c) {
                 assert!(
                     r.is_ok(),
                     "{c:?} should be a valid nucleotide or ambiguity code"
@@ -499,5 +499,4 @@ mod tests {
         protein(" angtnattag ");
         protein(" an  gtnattag ");
     }
-
 }

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -243,9 +243,13 @@ impl TryFrom<&[u8]> for DnaSequence {
     type Error = TranslationError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let mut vec = vec![Nucleotide::N; value.len()];
-        for (idx, &b) in value.iter().enumerate() {
-            vec[idx] = Nucleotide::try_from(b)?;
+        let mut vec = vec![];
+        vec.reserve(value.len());
+
+        for &b in value {
+            if b != b' ' {
+                vec.push(Nucleotide::try_from(b)?);
+            }
         }
         Ok(Self::new(vec))
     }
@@ -483,4 +487,17 @@ mod tests {
 
         assert_eq!(protein("antg").windows(10).next(), None);
     }
+
+    #[test]
+    fn test_empty_spaces() {
+        // this test will unwrap() if it can not parse the DNA
+        dna("gcantacctaangtnattag ");
+        dna("  gcantacctaangtnattag ");
+        dna(" gca ntac ctaangtnattag ");
+
+        protein("angtnattag ");
+        protein(" angtnattag ");
+        protein(" an  gtnattag ");
+    }
+
 }

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -247,7 +247,7 @@ impl TryFrom<&[u8]> for DnaSequence {
         vec.reserve(value.len());
 
         for &b in value {
-            if b != b' ' {
+            if b != b' ' && b != b'\t' {
                 vec.push(Nucleotide::try_from(b)?);
             }
         }
@@ -303,15 +303,15 @@ mod tests {
         for c in 0_u8..128 {
             let c = char::from(c);
             let r = DnaSequence::from_str(&String::from(c));
-            if "aAtTcCgGmMrRwWsSyYkKvVhHdDbBnN ".chars().any(|x| x == c) {
+            if "aAtTcCgGmMrRwWsSyYkKvVhHdDbBnN \t".chars().any(|x| x == c) {
                 assert!(
                     r.is_ok(),
-                    "{c:?} should be a valid nucleotide or ambiguity code"
+                    "{c:?} should be a valid nucleotide, ambiguity code, or allowed whitespace"
                 );
             } else {
                 assert!(
                     r.is_err(),
-                    "{c:?} should *not* be a valid nucleotide or ambiguity code"
+                    "{c:?} should *not* be a valid nucleotide, ambiguity code, or allowed whitespace"
                 );
             }
         }
@@ -490,13 +490,13 @@ mod tests {
 
     #[test]
     fn test_empty_spaces() {
-        // this test will unwrap() if it can not parse the DNA
+        // this test will unwrap() if it cannot parse the DNA
         dna("gcantacctaangtnattag ");
-        dna("  gcantacctaangtnattag ");
-        dna(" gca ntac ctaangtnattag ");
+        dna("  gcantac\tctaangtnattag ");
+        dna(" gca ntac ctaangtnattag \t");
 
         protein("angtnattag ");
         protein(" angtnattag ");
-        protein(" an  gtnattag ");
+        protein(" an  gtnattag \t");
     }
 }


### PR DESCRIPTION
This PR allows empty spaces (which get ignored) in DNA sequences.

Considerations:
- I did consider putting the check in nucleotides, but those should still error out. Its only DNA sequences that can contain nucleotide sequences with spaces in them.

Peptides accept empty spaces today and do not require a change. They also accept incorrect characters, but that is not the goal of this PR.