### PR TITLE
Add iterator-based API for interacting with DNA

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,10 @@ thiserror = "1.0.30"
 smallvec = "1.8.0"
 pyo3 = {version = "0.17.1", features = ["extension-module"], optional = true}
 
+[dev-dependencies]
+criterion = "0.4.0"
+rand = "0.8.5"
+
 [lib]
 name = "quickdna"
 crate-type = ["cdylib", "rlib"]
@@ -17,3 +21,7 @@ crate-type = ["cdylib", "rlib"]
 [features]
 python-support = ["dep:pyo3"]
 default = ["python-support"]
+
+[[bench]]
+name = "all_windows"
+harness = false

--- a/benches/all_windows.rs
+++ b/benches/all_windows.rs
@@ -117,8 +117,7 @@ impl IterBasedSequenceWindows {
         }));
         aas.extend(
             dna.iter()
-                .rev()
-                .complement()
+                .reverse_complement()
                 .self_reading_frames()
                 .into_iter()
                 .map(|codons| {
@@ -129,8 +128,7 @@ impl IterBasedSequenceWindows {
 
         let dna_rc = dna
             .iter()
-            .rev()
-            .complement()
+            .reverse_complement()
             .map(|n| n.to_ascii())
             .collect();
         let dna_rc = String::from_utf8(dna_rc).unwrap();

--- a/benches/all_windows.rs
+++ b/benches/all_windows.rs
@@ -111,13 +111,13 @@ impl IterBasedSequenceWindows {
     fn from_dna(dna: &[Nucleotide], dna_window_len: usize, protein_window_len: usize) -> Self {
         let mut aas = SmallVec::new();
         let ncbi1 = TranslationTable::Ncbi1.to_fn();
-        aas.extend(dna.reading_frames().into_iter().map(|codons| {
+        aas.extend(dna.self_reading_frames().into_iter().map(|codons| {
             let translated: Vec<_> = codons.map(ncbi1).collect();
             String::from_utf8(translated).unwrap()
         }));
         aas.extend(
             dna.reverse_complement()
-                .reading_frames()
+                .self_reading_frames()
                 .into_iter()
                 .map(|codons| {
                     let translated: Vec<_> = codons.map(ncbi1).collect();

--- a/benches/all_windows.rs
+++ b/benches/all_windows.rs
@@ -3,7 +3,7 @@ use rand::{rngs::OsRng, seq::SliceRandom};
 use smallvec::SmallVec;
 
 use quickdna::{
-    BaseSequence, DnaSequence, Nucleotide, NucleotideLike, Nucleotides, TranslationTable,
+    BaseSequence, DnaSequence, Nucleotide, NucleotideIter, NucleotideLike, TranslationTable,
 };
 
 static PROTEIN_WINDOW_LEN: usize = 20;
@@ -111,12 +111,13 @@ impl IterBasedSequenceWindows {
     fn from_dna(dna: &[Nucleotide], dna_window_len: usize, protein_window_len: usize) -> Self {
         let mut aas = SmallVec::new();
         let ncbi1 = TranslationTable::Ncbi1.to_fn();
-        aas.extend(dna.self_reading_frames().into_iter().map(|codons| {
+        aas.extend(dna.iter().self_reading_frames().into_iter().map(|codons| {
             let translated: Vec<_> = codons.map(ncbi1).collect();
             String::from_utf8(translated).unwrap()
         }));
         aas.extend(
-            dna.reverse_complement()
+            dna.iter()
+                .reverse_complement()
                 .self_reading_frames()
                 .into_iter()
                 .map(|codons| {
@@ -125,7 +126,11 @@ impl IterBasedSequenceWindows {
                 }),
         );
 
-        let dna_rc = (&dna).reverse_complement().map(|n| n.to_ascii()).collect();
+        let dna_rc = dna
+            .iter()
+            .reverse_complement()
+            .map(|n| n.to_ascii())
+            .collect();
         let dna_rc = String::from_utf8(dna_rc).unwrap();
 
         let dna = dna.iter().map(|n| n.to_ascii()).collect();

--- a/benches/all_windows.rs
+++ b/benches/all_windows.rs
@@ -1,0 +1,244 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::{rngs::OsRng, seq::SliceRandom};
+use smallvec::SmallVec;
+
+use quickdna::{
+    BaseSequence, DnaSequence, Nucleotide, NucleotideLike, Nucleotides, TranslationTable,
+};
+
+static PROTEIN_WINDOW_LEN: usize = 20;
+static DNA_WINDOW_LEN: usize = 42;
+
+// Adapted from synthclient
+#[derive(Debug, Clone)]
+pub struct SequenceWindows {
+    pub dna_sequence_length: usize,
+    pub dna: Vec<String>,
+    pub dna_reverse: Vec<String>,
+    pub aa: Vec<Vec<String>>,
+}
+
+impl SequenceWindows {
+    /// returns the combined length of all types of windows
+    fn len(&self) -> usize {
+        self.dna.len()
+            + self.dna_reverse.len()
+            + self
+                .aa
+                .iter()
+                .map(|ele| ele.len())
+                .reduce(|a, b| a + b)
+                .unwrap_or(0)
+    }
+
+    /// Returns an iterator over the windows and their original position in the full FASTA
+    /// The indexes returned by enumerate are not strictly monotonically increasing
+    fn enumerate(&self) -> impl Iterator<Item = (usize, &str)> {
+        self.dna
+            .iter()
+            .enumerate()
+            .map(|(i, s)| (i, s.as_str()))
+            .chain(
+                self.dna_reverse
+                    .iter()
+                    .enumerate()
+                    .map(|(index, value)| (self.dna_reverse.len() - index - 1, value.as_str())),
+            )
+            .chain(
+                self.aa
+                    .iter()
+                    .enumerate()
+                    .flat_map(move |(operation, frame_windows)| {
+                        // this code is the reverse of QuickDNA translate_all_frames
+                        // https://github.com/SecureDNA/quickdna/blob/main/src/rust_api.rs#L196
+                        let dna_per_aa = 3;
+                        frame_windows
+                            .iter()
+                            .enumerate()
+                            .map(move |(index_within_frame, window)| {
+                                if operation == 0 || operation == 1 || operation == 2 {
+                                    // forward
+                                    (dna_per_aa * index_within_frame + operation, window.as_str())
+                                } else {
+                                    // backwards
+                                    let index = self.dna_sequence_length
+                                        - ((index_within_frame + PROTEIN_WINDOW_LEN) * dna_per_aa
+                                            + (operation % 3));
+                                    (index, window.as_str())
+                                }
+                            })
+                    }),
+            )
+    }
+
+    /// Construct all windows from a DNA sequence
+    fn from_dna(dna: &DnaSequence<Nucleotide>) -> SequenceWindows {
+        let translations = dna.translate_all_frames(TranslationTable::Ncbi1);
+
+        let windows = SequenceWindows {
+            dna_sequence_length: dna.len(),
+            dna: dna.windows(DNA_WINDOW_LEN).map(|s| s.to_string()).collect(),
+            dna_reverse: dna
+                .reverse_complement()
+                .windows(DNA_WINDOW_LEN)
+                .map(|s| s.to_string())
+                .collect(),
+            aa: translations
+                .iter()
+                .map(|t| {
+                    t.windows(PROTEIN_WINDOW_LEN)
+                        .map(|s| s.to_string())
+                        .collect()
+                })
+                .collect(),
+        };
+
+        // amino acids
+        windows
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct IterBasedSequenceWindows {
+    dna_window_len: usize,
+    protein_window_len: usize,
+    dna: String,
+    dna_rc: String,
+    aas: SmallVec<[String; 6]>,
+}
+
+impl IterBasedSequenceWindows {
+    fn from_dna(dna: &[Nucleotide], dna_window_len: usize, protein_window_len: usize) -> Self {
+        let mut aas = SmallVec::new();
+        let ncbi1 = TranslationTable::Ncbi1.to_fn();
+        aas.extend(dna.reading_frames().into_iter().map(|codons| {
+            let translated: Vec<_> = codons.map(ncbi1).collect();
+            String::from_utf8(translated).unwrap()
+        }));
+        aas.extend(
+            dna.reverse_complement()
+                .reading_frames()
+                .into_iter()
+                .map(|codons| {
+                    let translated: Vec<_> = codons.map(ncbi1).collect();
+                    String::from_utf8(translated).unwrap()
+                }),
+        );
+
+        let dna_rc = (&dna).reverse_complement().map(|n| n.to_ascii()).collect();
+        let dna_rc = String::from_utf8(dna_rc).unwrap();
+
+        let dna = dna.iter().map(|n| n.to_ascii()).collect();
+        let dna = String::from_utf8(dna).unwrap();
+
+        Self {
+            dna_window_len,
+            protein_window_len,
+            dna,
+            dna_rc,
+            aas,
+        }
+    }
+
+    fn enumerate(&self) -> impl Iterator<Item = (usize, &str)> {
+        self.dna_windows()
+            .chain(self.dna_rc_windows())
+            .chain(self.aa_windows().flatten())
+    }
+
+    fn len(&self) -> usize {
+        let aas_len: usize = self.aa_windows().map(|iter| iter.len()).sum();
+        self.dna_windows().len() + self.dna_rc_windows().len() + aas_len
+    }
+
+    fn dna_windows(&self) -> impl ExactSizeIterator<Item = (usize, &str)> {
+        Self::ascii_str_windows(&self.dna, self.dna_window_len).enumerate()
+    }
+
+    fn dna_rc_windows(&self) -> impl ExactSizeIterator<Item = (usize, &str)> {
+        let first_dna_rc_idx = Self::num_windows(self.dna_rc.len(), self.dna_window_len) - 1;
+        Self::ascii_str_windows(&self.dna_rc, self.dna_window_len)
+            .enumerate()
+            .map(move |(i, w)| (first_dna_rc_idx - i, w))
+    }
+
+    fn aa_windows(
+        &self,
+    ) -> impl Iterator<Item = impl ExactSizeIterator<Item = (usize, &str)> + '_> + '_ {
+        // Thankfully, we don't actually need to worry about the edge-case where there are
+        // fewer than 6 reading frames. That can only happen if the dna sequence is <5 bases
+        // long, in which case the aas would be less than the protein window length and
+        // therefore lack any windows, making the exact logic of window generation moot.
+        (0..self.aas.len()).map(|frame_idx| {
+            let indices = self.aa_window_indices(frame_idx);
+            let windows = Self::ascii_str_windows(&self.aas[frame_idx], self.protein_window_len);
+            indices.zip(windows)
+        })
+    }
+
+    // Note: Imitates original logic so I can verify the iter-based window code is correct.
+    fn aa_window_indices(&self, frame_idx: usize) -> impl ExactSizeIterator<Item = usize> {
+        let dna_len = self.dna.len();
+        let protein_window_len = self.protein_window_len;
+        let num_windows = Self::num_windows(dna_len, protein_window_len);
+        let is_reverse = frame_idx >= 3;
+        let frame_offset = frame_idx % 3;
+        (0..num_windows).map(move |i| {
+            if is_reverse {
+                dna_len - ((i + protein_window_len) * 3 + frame_offset)
+            } else {
+                3 * i + frame_offset
+            }
+        })
+    }
+
+    // Unfortunate, but needed as long as we're using strings, AFAICT
+    fn ascii_str_windows(s: &str, window_len: usize) -> impl ExactSizeIterator<Item = &str> {
+        let num_windows = Self::num_windows(s.len(), window_len);
+        (0..num_windows).map(move |i| &s[i..i + window_len])
+    }
+
+    fn num_windows(data_len: usize, window_len: usize) -> usize {
+        data_len + 1 - window_len.min(data_len + 1)
+    }
+}
+
+pub fn criterion_benchmark(c: &mut Criterion) {
+    let nucleotides = [Nucleotide::A, Nucleotide::T, Nucleotide::C, Nucleotide::G];
+    let dna: Vec<_> = (0..99999)
+        .map(|_| *nucleotides.choose(&mut OsRng).unwrap())
+        .collect();
+    let dna = DnaSequence::new(dna);
+
+    // Sanity check that the iterator-based code behaves the same.
+    let baseline_windows = SequenceWindows::from_dna(&dna);
+    let new_windows =
+        IterBasedSequenceWindows::from_dna(dna.as_slice(), DNA_WINDOW_LEN, PROTEIN_WINDOW_LEN);
+    assert_eq!(new_windows.len(), baseline_windows.len());
+    assert!(new_windows.enumerate().eq(baseline_windows.enumerate()));
+
+    c.bench_function("DNASequence-based windows", |b| {
+        b.iter(|| {
+            let windows = SequenceWindows::from_dna(black_box(&dna));
+            for window in windows.enumerate() {
+                black_box(window);
+            }
+        })
+    });
+
+    c.bench_function("Iter-based windows", |b| {
+        b.iter(|| {
+            let windows = IterBasedSequenceWindows::from_dna(
+                black_box(dna.as_slice()),
+                DNA_WINDOW_LEN,
+                PROTEIN_WINDOW_LEN,
+            );
+            for window in windows.enumerate() {
+                black_box(window);
+            }
+        })
+    });
+}
+
+criterion_group!(benches, criterion_benchmark);
+criterion_main!(benches);

--- a/benches/all_windows.rs
+++ b/benches/all_windows.rs
@@ -117,7 +117,8 @@ impl IterBasedSequenceWindows {
         }));
         aas.extend(
             dna.iter()
-                .reverse_complement()
+                .rev()
+                .complement()
                 .self_reading_frames()
                 .into_iter()
                 .map(|codons| {
@@ -128,7 +129,8 @@ impl IterBasedSequenceWindows {
 
         let dna_rc = dna
             .iter()
-            .reverse_complement()
+            .rev()
+            .complement()
             .map(|n| n.to_ascii())
             .collect();
         let dna_rc = String::from_utf8(dna_rc).unwrap();

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -5,8 +5,8 @@ use crate::{Nucleotide, NucleotideAmbiguous, NucleotideLike};
 /// Helper trait to support iters regardless of whether their items are by-ref or by-value
 pub trait ToNucleotideLike
 where
-    // It's much easier for the compiler to reason about chained Nucleotides iterator
-    // adapters if we explicitly state that ToNucleotideLike is idempotent.
+    // It's much easier for the compiler to reason about chained NucleotideIters
+    // if we explicitly state that ToNucleotideLike is idempotent.
     Self::NucleotideType: ToNucleotideLike<NucleotideType = Self::NucleotideType>,
 {
     type NucleotideType: NucleotideLike + ToNucleotideLike;

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -152,6 +152,22 @@ pub trait NucleotideIter: Iterator + Sized {
     /// ```
     fn complement(self) -> Complement<Self>;
 
+    /// Returns iterator of reverse complement of contained nucleotides.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Nucleotide, NucleotideIter};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [C, G, A, T];
+    ///
+    /// assert!(dna.iter().reverse_complement().eq([A, T, C, G]));
+    /// ```
+    fn reverse_complement(self) -> std::iter::Rev<Complement<Self>>
+    where
+        Self: DoubleEndedIterator;
+
     /// Returns up to 3 non-empty codon iterators for reading frames.
     ///
     /// The iterators are given in ascending order of offset from the beginning of the
@@ -214,7 +230,7 @@ where
         let mut iter3 = iter2.clone();
         iter3.next();
 
-        let iter1_rc = iter1.clone().rev().complement();
+        let iter1_rc = iter1.clone().reverse_complement();
         let mut iter2_rc = iter1_rc.clone();
         iter2_rc.next();
         let mut iter3_rc = iter2_rc.clone();
@@ -238,6 +254,13 @@ where
 
     fn complement(self) -> Complement<Self> {
         Complement(self)
+    }
+
+    fn reverse_complement(self) -> std::iter::Rev<Complement<Self>>
+    where
+        Self: DoubleEndedIterator,
+    {
+        self.complement().rev()
     }
 
     fn self_reading_frames(self) -> SmallVec<[Codons<Self>; 3]>
@@ -365,7 +388,7 @@ where
 #[derive(Clone, Debug)]
 pub enum ForwardOrRcCodons<I> {
     Forward(Codons<I>),
-    Rc(Codons<Complement<std::iter::Rev<I>>>),
+    Rc(Codons<std::iter::Rev<Complement<I>>>),
 }
 
 impl<N, I> Iterator for ForwardOrRcCodons<I>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -3,8 +3,13 @@ use smallvec::SmallVec;
 use crate::{Nucleotide, NucleotideAmbiguous, NucleotideLike};
 
 /// Helper trait to support iters regardless of whether their items are by-ref or by-value
-pub trait ToNucleotideLike {
-    type NucleotideType: NucleotideLike;
+pub trait ToNucleotideLike
+where
+    // It's much easier for the compiler to reason about chained Nucleotides iterator
+    // adapters if we explicitly state that ToNucleotideLike is idempotent.
+    Self::NucleotideType: ToNucleotideLike<NucleotideType = Self::NucleotideType>,
+{
+    type NucleotideType: NucleotideLike + ToNucleotideLike;
 
     fn to_nucleotide_like(self) -> Self::NucleotideType;
 }
@@ -43,10 +48,77 @@ impl ToNucleotideLike for &NucleotideAmbiguous {
 
 /// Extension trait for nucleotide sequences
 pub trait Nucleotides: IntoIterator {
+    /// Returns up to 6 non-empty codon iterators for forward and reverse complement reading frames.
+    ///
+    /// The foward codon iterators are given before the reverse complement ones, with the forward
+    /// codon iterators given in ascending order by offset from the beginning of the nucleotide
+    /// sequence and the reverse complement codon iterators given in ascending order by offset
+    /// from the end.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Nucleotide, Nucleotides};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [C, G, A, T, C, G, A, T];
+    ///
+    /// let frames = dna.all_reading_frames();
+    /// assert_eq!(frames.len(), 6);
+    /// assert!(frames[0].clone().eq([
+    ///     [C, G, A].into(),
+    ///     [T, C, G].into(),
+    /// ]));
+    /// assert!(frames[1].clone().eq([
+    ///     [G, A, T].into(),
+    ///     [C, G, A].into(),
+    /// ]));
+    /// assert!(frames[2].clone().eq([
+    ///     [A, T, C].into(),
+    ///     [G, A, T].into(),
+    /// ]));
+    /// assert!(frames[3].clone().eq([
+    ///     [A, T, C].into(),
+    ///     [G, A, T].into(),
+    /// ]));
+    /// assert!(frames[4].clone().eq([
+    ///     [T, C, G].into(),
+    ///     [A, T, C].into(),
+    /// ]));
+    /// assert!(frames[5].clone().eq([
+    ///     [C, G, A].into(),
+    ///     [T, C, G].into(),
+    /// ]));
+    ///
+    /// // The last forward and RC reading frames are omitted
+    /// // because they would only have 2 nucleotides.
+    /// let frames = dna[..4].all_reading_frames();
+    /// assert_eq!(frames.len(), 4);
+    /// assert!(frames[0].clone().eq([
+    ///     [C, G, A].into(),
+    /// ]));
+    /// assert!(frames[1].clone().eq([
+    ///     [G, A, T].into(),
+    /// ]));
+    /// assert!(frames[2].clone().eq([
+    ///     [A, T, C].into(),
+    /// ]));
+    /// assert!(frames[3].clone().eq([
+    ///     [T, C, G].into(),
+    /// ]));
+    ///
+    /// // All reading frames are omitted due to insufficient nucleotides.
+    /// let frames = dna[..2].all_reading_frames();
+    /// assert!(frames.is_empty());
+    /// ```
+    fn all_reading_frames(self) -> SmallVec<[ForwardOrRcCodons<Self::IntoIter>; 6]>
+    where
+        Self::IntoIter: Clone + DoubleEndedIterator + ExactSizeIterator;
+
     /// Returns iterator of codons for the first reading frame of this nucleotide sequence.
     /// If the number of nucleotides isn't divisible by 3, excess nucleotides are silently
     /// discarded. Note that if the returned iterator is non-empty, it is the same as the
-    /// first element of [`reading_frames`](Self::reading_frames).
+    /// first element of [`self_reading_frames`](Self::self_reading_frames).
     ///
     /// # Examples
     ///
@@ -62,7 +134,7 @@ pub trait Nucleotides: IntoIterator {
     /// ];
     /// assert!(dna.codons().eq(expected_codons));
     ///
-    /// assert!(dna.codons().eq(dna.reading_frames().remove(0)));
+    /// assert!(dna.codons().eq(dna.self_reading_frames().remove(0)));
     /// ```
     fn codons(self) -> Codons<Self::IntoIter>;
 
@@ -80,52 +152,6 @@ pub trait Nucleotides: IntoIterator {
     /// ```
     fn complement(self) -> Complement<Self::IntoIter>;
 
-    /// Returns up to 3 non-empty codon iterators for reading frames.
-    ///
-    /// The iterators are given in ascending order of offset from the beginning of the
-    /// nucleotide sequence.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use quickdna::{Nucleotide, Nucleotides};
-    ///
-    /// use Nucleotide::*;
-    /// let dna = [C, G, A, T, C, G, A, T];
-    ///
-    /// let frames = dna.reading_frames();
-    /// assert_eq!(frames.len(), 3);
-    /// assert!(frames[0].clone().eq([
-    ///     [C, G, A].into(),
-    ///     [T, C, G].into(),
-    /// ]));
-    /// assert!(frames[1].clone().eq([
-    ///     [G, A, T].into(),
-    ///     [C, G, A].into(),
-    /// ]));
-    /// assert!(frames[2].clone().eq([
-    ///     [A, T, C].into(),
-    ///     [G, A, T].into(),
-    /// ]));
-    ///
-    /// // The last reading frame is omitted because it would only have 2 nucleotides.
-    /// let frames = dna[..4].reading_frames();
-    /// assert_eq!(frames.len(), 2);
-    /// assert!(frames[0].clone().eq([
-    ///     [C, G, A].into(),
-    /// ]));
-    /// assert!(frames[1].clone().eq([
-    ///     [G, A, T].into(),
-    /// ]));
-    ///
-    /// // All reading frames are omitted due to insufficient nucleotides.
-    /// let frames = dna[..2].reading_frames();
-    /// assert!(frames.is_empty());
-    /// ```
-    fn reading_frames(self) -> SmallVec<[Codons<Self::IntoIter>; 3]>
-    where
-        Self::IntoIter: Clone + ExactSizeIterator;
-
     /// Returns iterator of reverse complement of contained nucleotides.
     ///
     /// # Examples
@@ -141,6 +167,52 @@ pub trait Nucleotides: IntoIterator {
     fn reverse_complement(self) -> std::iter::Rev<Complement<Self::IntoIter>>
     where
         Self::IntoIter: DoubleEndedIterator;
+
+    /// Returns up to 3 non-empty codon iterators for reading frames.
+    ///
+    /// The iterators are given in ascending order of offset from the beginning of the
+    /// nucleotide sequence.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Nucleotide, Nucleotides};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [C, G, A, T, C, G, A, T];
+    ///
+    /// let frames = dna.self_reading_frames();
+    /// assert_eq!(frames.len(), 3);
+    /// assert!(frames[0].clone().eq([
+    ///     [C, G, A].into(),
+    ///     [T, C, G].into(),
+    /// ]));
+    /// assert!(frames[1].clone().eq([
+    ///     [G, A, T].into(),
+    ///     [C, G, A].into(),
+    /// ]));
+    /// assert!(frames[2].clone().eq([
+    ///     [A, T, C].into(),
+    ///     [G, A, T].into(),
+    /// ]));
+    ///
+    /// // The last reading frame is omitted because it would only have 2 nucleotides.
+    /// let frames = dna[..4].self_reading_frames();
+    /// assert_eq!(frames.len(), 2);
+    /// assert!(frames[0].clone().eq([
+    ///     [C, G, A].into(),
+    /// ]));
+    /// assert!(frames[1].clone().eq([
+    ///     [G, A, T].into(),
+    /// ]));
+    ///
+    /// // All reading frames are omitted due to insufficient nucleotides.
+    /// let frames = dna[..2].self_reading_frames();
+    /// assert!(frames.is_empty());
+    /// ```
+    fn self_reading_frames(self) -> SmallVec<[Codons<Self::IntoIter>; 3]>
+    where
+        Self::IntoIter: Clone + ExactSizeIterator;
 }
 
 impl<N, I, T> Nucleotides for T
@@ -149,6 +221,34 @@ where
     I: Iterator<Item = N>,
     T: IntoIterator<IntoIter = I>,
 {
+    fn all_reading_frames(self) -> SmallVec<[ForwardOrRcCodons<Self::IntoIter>; 6]>
+    where
+        Self::IntoIter: Clone + DoubleEndedIterator + ExactSizeIterator,
+    {
+        let iter1 = self.into_iter();
+        let mut iter2 = iter1.clone();
+        iter2.next();
+        let mut iter3 = iter2.clone();
+        iter3.next();
+
+        let iter1_rc = iter1.clone().reverse_complement();
+        let mut iter2_rc = iter1_rc.clone();
+        iter2_rc.next();
+        let mut iter3_rc = iter2_rc.clone();
+        iter3_rc.next();
+
+        let mut frames = SmallVec::from([
+            ForwardOrRcCodons::Forward(iter1.codons()),
+            ForwardOrRcCodons::Forward(iter2.codons()),
+            ForwardOrRcCodons::Forward(iter3.codons()),
+            ForwardOrRcCodons::Rc(iter1_rc.codons()),
+            ForwardOrRcCodons::Rc(iter2_rc.codons()),
+            ForwardOrRcCodons::Rc(iter3_rc.codons()),
+        ]);
+        frames.retain(|frame| frame.len() > 0);
+        frames
+    }
+
     fn codons(self) -> Codons<Self::IntoIter> {
         Codons(self.into_iter())
     }
@@ -157,7 +257,14 @@ where
         Complement(self.into_iter())
     }
 
-    fn reading_frames(self) -> SmallVec<[Codons<Self::IntoIter>; 3]>
+    fn reverse_complement(self) -> std::iter::Rev<Complement<Self::IntoIter>>
+    where
+        Self::IntoIter: DoubleEndedIterator,
+    {
+        self.complement().rev()
+    }
+
+    fn self_reading_frames(self) -> SmallVec<[Codons<Self::IntoIter>; 3]>
     where
         Self::IntoIter: Clone + ExactSizeIterator,
     {
@@ -169,13 +276,6 @@ where
         let mut frames = SmallVec::from([iter1.codons(), iter2.codons(), iter3.codons()]);
         frames.retain(|frame| frame.len() > 0);
         frames
-    }
-
-    fn reverse_complement(self) -> std::iter::Rev<Complement<Self::IntoIter>>
-    where
-        Self::IntoIter: DoubleEndedIterator,
-    {
-        self.complement().rev()
     }
 }
 
@@ -270,6 +370,58 @@ where
 }
 
 impl<I> ExactSizeIterator for Complement<I>
+where
+    Self: Iterator,
+    I: ExactSizeIterator,
+{
+}
+
+/// Adapter capable of holding either forward codon iterators or reverse complement codon iterators.
+///
+/// This `struct` is created by the [`all_reading_frames`](Nucleotides::all_reading_frames)
+/// method on [`Nucleotides`]. See its documentation for more.
+#[derive(Clone, Debug)]
+pub enum ForwardOrRcCodons<I> {
+    Forward(Codons<I>),
+    Rc(Codons<std::iter::Rev<Complement<I>>>),
+}
+
+impl<N, I> Iterator for ForwardOrRcCodons<I>
+where
+    N: ToNucleotideLike,
+    I: DoubleEndedIterator<Item = N> + ExactSizeIterator,
+{
+    type Item = <N::NucleotideType as NucleotideLike>::Codon;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Forward(iter) => iter.next(),
+            Self::Rc(iter) => iter.next(),
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        match self {
+            Self::Forward(iter) => iter.size_hint(),
+            Self::Rc(iter) => iter.size_hint(),
+        }
+    }
+}
+
+impl<N, I> DoubleEndedIterator for ForwardOrRcCodons<I>
+where
+    N: ToNucleotideLike,
+    I: DoubleEndedIterator<Item = N> + ExactSizeIterator,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::Forward(iter) => iter.next_back(),
+            Self::Rc(iter) => iter.next_back(),
+        }
+    }
+}
+
+impl<I> ExactSizeIterator for ForwardOrRcCodons<I>
 where
     Self: Iterator,
     I: ExactSizeIterator,

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -332,6 +332,9 @@ where
     Self: Iterator,
     I: ExactSizeIterator,
 {
+    fn len(&self) -> usize {
+        self.0.len() / 3
+    }
 }
 
 /// Adapter yielding complementary nucleotide of the contained iterator.
@@ -374,6 +377,9 @@ where
     Self: Iterator,
     I: ExactSizeIterator,
 {
+    fn len(&self) -> usize {
+        self.0.len()
+    }
 }
 
 /// Adapter capable of holding either forward codon iterators or reverse complement codon iterators.
@@ -389,7 +395,7 @@ pub enum ForwardOrRcCodons<I> {
 impl<N, I> Iterator for ForwardOrRcCodons<I>
 where
     N: ToNucleotideLike,
-    I: DoubleEndedIterator<Item = N> + ExactSizeIterator,
+    I: DoubleEndedIterator<Item = N>,
 {
     type Item = <N::NucleotideType as NucleotideLike>::Codon;
 
@@ -421,11 +427,18 @@ where
     }
 }
 
-impl<I> ExactSizeIterator for ForwardOrRcCodons<I>
+impl<N, I> ExactSizeIterator for ForwardOrRcCodons<I>
 where
     Self: Iterator,
-    I: ExactSizeIterator,
+    N: ToNucleotideLike,
+    I: DoubleEndedIterator<Item = N> + ExactSizeIterator,
 {
+    fn len(&self) -> usize {
+        match self {
+            Self::Forward(iter) => iter.len(),
+            Self::Rc(iter) => iter.len(),
+        }
+    }
 }
 
 #[cfg(test)]

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -164,7 +164,7 @@ pub trait NucleotideIter: Iterator + Sized {
     ///
     /// assert!(dna.iter().reverse_complement().eq([A, T, C, G]));
     /// ```
-    fn reverse_complement(self) -> std::iter::Rev<Complement<Self>>
+    fn reverse_complement(self) -> Complement<std::iter::Rev<Self>>
     where
         Self: DoubleEndedIterator;
 
@@ -256,11 +256,11 @@ where
         Complement(self)
     }
 
-    fn reverse_complement(self) -> std::iter::Rev<Complement<Self>>
+    fn reverse_complement(self) -> Complement<std::iter::Rev<Self>>
     where
         Self: DoubleEndedIterator,
     {
-        self.complement().rev()
+        self.rev().complement()
     }
 
     fn self_reading_frames(self) -> SmallVec<[Codons<Self>; 3]>
@@ -388,7 +388,7 @@ where
 #[derive(Clone, Debug)]
 pub enum ForwardOrRcCodons<I> {
     Forward(Codons<I>),
-    Rc(Codons<std::iter::Rev<Complement<I>>>),
+    Rc(Codons<Complement<std::iter::Rev<I>>>),
 }
 
 impl<N, I> Iterator for ForwardOrRcCodons<I>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -152,22 +152,6 @@ pub trait NucleotideIter: Iterator + Sized {
     /// ```
     fn complement(self) -> Complement<Self>;
 
-    /// Returns iterator of reverse complement of contained nucleotides.
-    ///
-    /// # Examples
-    ///
-    /// ```
-    /// use quickdna::{Nucleotide, NucleotideIter};
-    ///
-    /// use Nucleotide::*;
-    /// let dna = [C, G, A, T];
-    ///
-    /// assert!(dna.iter().reverse_complement().eq([A, T, C, G]));
-    /// ```
-    fn reverse_complement(self) -> std::iter::Rev<Complement<Self>>
-    where
-        Self: DoubleEndedIterator;
-
     /// Returns up to 3 non-empty codon iterators for reading frames.
     ///
     /// The iterators are given in ascending order of offset from the beginning of the
@@ -230,7 +214,7 @@ where
         let mut iter3 = iter2.clone();
         iter3.next();
 
-        let iter1_rc = iter1.clone().reverse_complement();
+        let iter1_rc = iter1.clone().rev().complement();
         let mut iter2_rc = iter1_rc.clone();
         iter2_rc.next();
         let mut iter3_rc = iter2_rc.clone();
@@ -254,13 +238,6 @@ where
 
     fn complement(self) -> Complement<Self> {
         Complement(self)
-    }
-
-    fn reverse_complement(self) -> std::iter::Rev<Complement<Self>>
-    where
-        Self: DoubleEndedIterator,
-    {
-        self.complement().rev()
     }
 
     fn self_reading_frames(self) -> SmallVec<[Codons<Self>; 3]>
@@ -388,7 +365,7 @@ where
 #[derive(Clone, Debug)]
 pub enum ForwardOrRcCodons<I> {
     Forward(Codons<I>),
-    Rc(Codons<std::iter::Rev<Complement<I>>>),
+    Rc(Codons<Complement<std::iter::Rev<I>>>),
 }
 
 impl<N, I> Iterator for ForwardOrRcCodons<I>

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,273 @@
+use smallvec::SmallVec;
+
+use crate::{Nucleotide, NucleotideAmbiguous, NucleotideLike};
+
+/// Helper trait to support iters regardless of whether their items are by-ref or by-value
+pub trait ToNucleotideLike {
+    type NucleotideType: NucleotideLike;
+
+    fn to_nucleotide_like(self) -> Self::NucleotideType;
+}
+
+impl ToNucleotideLike for Nucleotide {
+    type NucleotideType = Nucleotide;
+
+    fn to_nucleotide_like(self) -> Nucleotide {
+        self
+    }
+}
+
+impl ToNucleotideLike for &Nucleotide {
+    type NucleotideType = Nucleotide;
+
+    fn to_nucleotide_like(self) -> Nucleotide {
+        *self
+    }
+}
+
+impl ToNucleotideLike for NucleotideAmbiguous {
+    type NucleotideType = NucleotideAmbiguous;
+
+    fn to_nucleotide_like(self) -> NucleotideAmbiguous {
+        self
+    }
+}
+
+impl ToNucleotideLike for &NucleotideAmbiguous {
+    type NucleotideType = NucleotideAmbiguous;
+
+    fn to_nucleotide_like(self) -> NucleotideAmbiguous {
+        *self
+    }
+}
+
+/// Extension trait for nucleotide sequences
+pub trait Nucleotides: IntoIterator {
+    /// Returns iterator of codons for the first reading frame of this nucleotide sequence.
+    /// If the number of nucleotides isn't divisible by 3, excess nucleotides are silently
+    /// discarded. Note that if the returned iterator is non-empty, it is the same as the
+    /// first element of [`reading_frames`](Self::reading_frames).
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Codons, Nucleotide, Nucleotides};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [C, G, A, T, C, G, A, T];
+    ///
+    /// let expected_codons = [
+    ///     [C, G, A].into(),
+    ///     [T, C, G].into(),
+    /// ];
+    /// assert!(dna.codons().eq(expected_codons));
+    ///
+    /// assert!(dna.codons().eq(dna.reading_frames().remove(0)));
+    /// ```
+    fn codons(self) -> Codons<Self::IntoIter>;
+
+    /// Returns iterator of complementary nucleotides.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Nucleotide, Nucleotides};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [C, G, A, T];
+    ///
+    /// assert!(dna.complement().eq([G, C, T, A]));
+    /// ```
+    fn complement(self) -> Complement<Self::IntoIter>;
+
+    /// Returns up to 3 non-empty codon iterators for reading frames.
+    ///
+    /// The iterators are given in ascending order of offset from the beginning of the
+    /// nucleotide sequence.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Nucleotide, Nucleotides};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [C, G, A, T, C, G, A, T];
+    ///
+    /// let frames = dna.reading_frames();
+    /// assert_eq!(frames.len(), 3);
+    /// assert!(frames[0].clone().eq([
+    ///     [C, G, A].into(),
+    ///     [T, C, G].into(),
+    /// ]));
+    /// assert!(frames[1].clone().eq([
+    ///     [G, A, T].into(),
+    ///     [C, G, A].into(),
+    /// ]));
+    /// assert!(frames[2].clone().eq([
+    ///     [A, T, C].into(),
+    ///     [G, A, T].into(),
+    /// ]));
+    ///
+    /// // The last reading frame is omitted because it would only have 2 nucleotides.
+    /// let frames = dna[..4].reading_frames();
+    /// assert_eq!(frames.len(), 2);
+    /// assert!(frames[0].clone().eq([
+    ///     [C, G, A].into(),
+    /// ]));
+    /// assert!(frames[1].clone().eq([
+    ///     [G, A, T].into(),
+    /// ]));
+    ///
+    /// // All reading frames are omitted due to insufficient nucleotides.
+    /// let frames = dna[..2].reading_frames();
+    /// assert!(frames.is_empty());
+    /// ```
+    fn reading_frames(self) -> SmallVec<[Codons<Self::IntoIter>; 3]>
+    where
+        Self::IntoIter: Clone + ExactSizeIterator;
+
+    /// Returns iterator of reverse complement of contained nucleotides.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Nucleotide, Nucleotides};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [C, G, A, T];
+    ///
+    /// assert!(dna.reverse_complement().eq([A, T, C, G]));
+    /// ```
+    fn reverse_complement(self) -> std::iter::Rev<Complement<Self::IntoIter>>
+    where
+        Self::IntoIter: DoubleEndedIterator;
+}
+
+impl<N, I, T> Nucleotides for T
+where
+    N: ToNucleotideLike,
+    I: Iterator<Item = N>,
+    T: IntoIterator<IntoIter = I>,
+{
+    fn codons(self) -> Codons<Self::IntoIter> {
+        Codons(self.into_iter())
+    }
+
+    fn complement(self) -> Complement<Self::IntoIter> {
+        Complement(self.into_iter())
+    }
+
+    fn reading_frames(self) -> SmallVec<[Codons<Self::IntoIter>; 3]>
+    where
+        Self::IntoIter: Clone + ExactSizeIterator,
+    {
+        let iter1 = self.into_iter();
+        let mut iter2 = iter1.clone();
+        iter2.next();
+        let mut iter3 = iter2.clone();
+        iter3.next();
+        let mut frames = SmallVec::from([iter1.codons(), iter2.codons(), iter3.codons()]);
+        frames.retain(|frame| frame.len() > 0);
+        frames
+    }
+
+    fn reverse_complement(self) -> std::iter::Rev<Complement<Self::IntoIter>>
+    where
+        Self::IntoIter: DoubleEndedIterator,
+    {
+        self.complement().rev()
+    }
+}
+
+/// Adapter yielding codons of the contained iterator.
+///
+/// This `struct` is created by the [`codons`](Nucleotides::codons)
+/// method on [`Nucleotides`]. See its documentation for more.
+#[derive(Clone, Debug)]
+pub struct Codons<I>(I);
+
+impl<N, I> Iterator for Codons<I>
+where
+    N: ToNucleotideLike,
+    I: Iterator<Item = N>,
+{
+    type Item = <N::NucleotideType as NucleotideLike>::Codon;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match (self.0.next(), self.0.next(), self.0.next()) {
+            (Some(n1), Some(n2), Some(n3)) => {
+                Some([n1, n2, n3].map(|n| n.to_nucleotide_like()).into())
+            }
+            _ => None,
+        }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        let (min, max) = self.0.size_hint();
+        (min / 3, max.map(|m| m / 3))
+    }
+}
+
+impl<N, I> DoubleEndedIterator for Codons<I>
+where
+    N: ToNucleotideLike,
+    I: DoubleEndedIterator<Item = N>,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        match (self.0.next_back(), self.0.next_back(), self.0.next_back()) {
+            (Some(n1), Some(n2), Some(n3)) => {
+                Some([n1, n2, n3].map(|n| n.to_nucleotide_like()).into())
+            }
+            _ => None,
+        }
+    }
+}
+
+impl<I> ExactSizeIterator for Codons<I>
+where
+    Self: Iterator,
+    I: ExactSizeIterator,
+{
+}
+
+/// Adapter yielding complementary nucleotide of the contained iterator.
+///
+/// This `struct` is created by the [`complement`](Nucleotides::complement)
+/// method on [`Nucleotides`]. See its documentation for more.
+#[derive(Clone, Debug)]
+pub struct Complement<I>(I);
+
+impl<N, I> Iterator for Complement<I>
+where
+    N: ToNucleotideLike,
+    I: Iterator<Item = N>,
+{
+    type Item = N::NucleotideType;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.0.next().map(|n| n.to_nucleotide_like().complement())
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        self.0.size_hint()
+    }
+}
+
+impl<N, I> DoubleEndedIterator for Complement<I>
+where
+    N: ToNucleotideLike,
+    I: DoubleEndedIterator<Item = N>,
+{
+    fn next_back(&mut self) -> Option<Self::Item> {
+        self.0
+            .next_back()
+            .map(|n| n.to_nucleotide_like().complement())
+    }
+}
+
+impl<I> ExactSizeIterator for Complement<I>
+where
+    Self: Iterator,
+    I: ExactSizeIterator,
+{
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,9 @@ pub mod trans_table; // needs to be public for bin/gen_table
 mod fasta;
 pub use fasta::*;
 
+mod iter;
+pub use iter::*;
+
 mod rust_api;
 pub use rust_api::*;
 

--- a/src/nucleotide.rs
+++ b/src/nucleotide.rs
@@ -41,6 +41,8 @@ pub enum NucleotideAmbiguous {
 pub trait NucleotideLike:
     Copy + Eq + Into<u8> + Into<char> + TryFrom<u8, Error = TranslationError>
 {
+    type Codon: From<[Self; 3]>;
+
     fn complement(self) -> Self;
     fn bits(self) -> u8;
     fn to_ascii(self) -> u8;
@@ -104,6 +106,8 @@ impl Nucleotide {
 }
 
 impl NucleotideLike for Nucleotide {
+    type Codon = Codon;
+
     fn complement(self) -> Self {
         match self {
             Self::A => Self::T,
@@ -172,6 +176,8 @@ impl NucleotideAmbiguous {
 }
 
 impl NucleotideLike for NucleotideAmbiguous {
+    type Codon = CodonAmbiguous;
+
     fn complement(self) -> Self {
         match self {
             Self::A => Self::T,
@@ -333,6 +339,12 @@ impl TryFrom<[u8; 3]> for Codon {
     }
 }
 
+impl From<[Nucleotide; 3]> for Codon {
+    fn from(nucleotides: [Nucleotide; 3]) -> Self {
+        Codon(nucleotides)
+    }
+}
+
 impl From<Codon> for [Nucleotide; 3] {
     fn from(c: Codon) -> Self {
         c.0
@@ -357,6 +369,12 @@ impl TryFrom<[u8; 3]> for CodonAmbiguous {
             NucleotideAmbiguous::try_from(value[1])?,
             NucleotideAmbiguous::try_from(value[2])?,
         ]))
+    }
+}
+
+impl From<[NucleotideAmbiguous; 3]> for CodonAmbiguous {
+    fn from(nucleotides: [NucleotideAmbiguous; 3]) -> Self {
+        CodonAmbiguous(nucleotides)
     }
 }
 

--- a/src/trans_table.rs
+++ b/src/trans_table.rs
@@ -146,6 +146,19 @@ impl TranslationTable {
     ///
     /// Currently, amino acids are represented as [`u8`]s containing the ascii
     /// code for the corresponding letter abbreviation.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use quickdna::{Nucleotide, NucleotideIter, TranslationTable};
+    ///
+    /// use Nucleotide::*;
+    /// let dna = [A, T, C, G, A, T, C, G];
+    ///
+    /// let ncbi1 = TranslationTable::Ncbi1.to_fn();
+    /// let aas = dna.iter().codons().map(ncbi1);
+    /// assert!(aas.eq([b'I', b'D']));
+    /// ```
     pub fn to_fn<C: Into<CodonIdx>>(self) -> impl Copy + Fn(C) -> u8 {
         let start = self.table_index() * Self::CODONS_PER_TABLE;
         let end = start + Self::CODONS_PER_TABLE;

--- a/src/trans_table.rs
+++ b/src/trans_table.rs
@@ -142,6 +142,20 @@ impl TranslationTable {
         }
     }
 
+    /// Convert this table to a callable that maps codons to amino acids
+    ///
+    /// Currently, amino acids are represented as [`u8`]s containing the ascii
+    /// code for the corresponding letter abbreviation.
+    pub fn to_fn<C: Into<CodonIdx>>(self) -> impl Copy + Fn(C) -> u8 {
+        let start = self.table_index() * Self::CODONS_PER_TABLE;
+        let end = start + Self::CODONS_PER_TABLE;
+        let table = &Self::TRANSLATION_TABLES[start..end];
+        |codon| {
+            let CodonIdx(i) = codon.into();
+            table[i]
+        }
+    }
+
     pub fn translate_dna_bytes<T: NucleotideLike>(
         self,
         dna: &[u8],


### PR DESCRIPTION
This provides a more polished version of the API shown in in #19, hopefully making it easier to work with DNA stored in more kinds of data structures. I've also included a benchmark for using this API to generate windows with fewer allocations, though it doesn't fully satisfy #20 because we still store AAs as `&str`s, preventing us from using Rust's standard windowing.
