### PR TITLE
Give FastaRecord a to_string() method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickdna"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2021"
 authors = ["Theia Vogel <theia@vgel.me>"]
 

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -41,16 +41,16 @@ impl FastaRecord<String> {
     }
 }
 
-impl<T: ToString> Display for FastaRecord<T> {
+impl<T: Display> Display for FastaRecord<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if !self.header.is_empty() {
             writeln!(f, ">{}", self.header.replace('\n', "\n>"))?;
         }
-        writeln!(f, "{}", self.contents.to_string())
+        writeln!(f, "{}", self.contents)
     }
 }
 
-impl<T: ToString> Display for FastaFile<T> {
+impl<T: Display> Display for FastaFile<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for record in &self.records {
             write!(f, "{}", record)?;

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -1340,13 +1340,10 @@ mod tests {
 
         // Test: if we to_string the parsed file and parse it again, we should
         // get the same records again, ignoring line_range.
-        let restrung = parsed.to_string();
-        let reparsed = parser.parse_str(&restrung).unwrap();
+        let reparsed = parser.parse_str(&parsed.to_string()).unwrap();
 
         assert_eq!(parsed.records.len(), 3);
         assert_eq!(reparsed.records.len(), 3);
-
-        // Compare all records, but ignore line_range:
         for i in 0..3 {
             assert_eq!(parsed.records[i].header, reparsed.records[i].header);
             assert_eq!(parsed.records[i].contents, reparsed.records[i].contents);

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -38,9 +38,9 @@ impl FastaRecord<String> {
 impl<T: ToString> Display for FastaRecord<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         if !self.header.is_empty() {
-            write!(f, ">{}\n", self.header.replace("\n", "\n>"))?;
+            writeln!(f, ">{}", self.header.replace('\n', "\n>"))?;
         }
-        write!(f, "{}\n", self.contents.to_string())
+        writeln!(f, "{}", self.contents.to_string())
     }
 }
 

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -569,9 +569,9 @@ mod tests {
         let p1 = protein("aaa");
         let p2 = protein("aaa");
 
-        assert_eq!(hash(&d1), hash(&d2));
+        assert_eq!(hash(&d1), hash(d2));
         assert!(hash(&d1) != hash(&p1));
-        assert_eq!(hash(&p1), hash(&p2));
+        assert_eq!(hash(&p1), hash(p2));
     }
 
     #[test]
@@ -581,9 +581,9 @@ mod tests {
         let p1 = protein("aaa");
         let p2 = protein("aaa");
 
-        assert_eq!(hash(&d1), hash(&d2));
+        assert_eq!(hash(&d1), hash(d2));
         assert!(hash(&d1) != hash(&p1));
-        assert_eq!(hash(&p1), hash(&p2));
+        assert_eq!(hash(&p1), hash(p2));
     }
 
     #[test]


### PR DESCRIPTION
This `Display` impl converts the parsed record back into FASTA `>header\ncontents\n` format. Implementing `Display` automatically gets us `ToString` and `.to_string()`.

(We want this because it's the easiest way to turn a `Vec<FastaRecord>` contained in an ELT back into a string to ASN.1-encode it.)