### PR TITLE
Add quickcheck support for Nucleotide and NucleotideAmbiguous

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ lazy_static = "1.4.0"
 thiserror = "1.0.30"
 smallvec = "1.8.0"
 pyo3 = {version = "0.17.1", features = ["extension-module"], optional = true}
+quickcheck = {version = "1.0.3", optional = true}
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,3 +20,6 @@ mod python_api;
 
 #[cfg(feature = "python-support")]
 pub use python_api::*;
+
+#[cfg(feature = "quickcheck")]
+mod quickcheck;

--- a/src/quickcheck.rs
+++ b/src/quickcheck.rs
@@ -1,0 +1,59 @@
+use quickcheck::{Arbitrary, Gen};
+
+use crate::{Codon, CodonAmbiguous, DnaSequence, Nucleotide, NucleotideAmbiguous, NucleotideLike};
+
+impl Arbitrary for Nucleotide {
+    fn arbitrary(g: &mut Gen) -> Self {
+        *g.choose(&[Self::A, Self::T, Self::C, Self::G])
+            .expect("Gen should be able to choose a Nucleotide")
+    }
+}
+
+impl Arbitrary for NucleotideAmbiguous {
+    fn arbitrary(g: &mut Gen) -> Self {
+        *g.choose(&[
+            Self::A,
+            Self::T,
+            Self::C,
+            Self::G,
+            Self::W,
+            Self::M,
+            Self::R,
+            Self::Y,
+            Self::S,
+            Self::K,
+            Self::B,
+            Self::V,
+            Self::D,
+            Self::H,
+            Self::N,
+        ])
+        .expect("Gen should be able to choose a NucleotideAmbiguous")
+    }
+}
+
+impl Arbitrary for Codon {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self([
+            Nucleotide::arbitrary(g),
+            Nucleotide::arbitrary(g),
+            Nucleotide::arbitrary(g),
+        ])
+    }
+}
+
+impl Arbitrary for CodonAmbiguous {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self([
+            NucleotideAmbiguous::arbitrary(g),
+            NucleotideAmbiguous::arbitrary(g),
+            NucleotideAmbiguous::arbitrary(g),
+        ])
+    }
+}
+
+impl<T: Arbitrary + NucleotideLike> Arbitrary for DnaSequence<T> {
+    fn arbitrary(g: &mut Gen) -> Self {
+        Self::new(Arbitrary::arbitrary(g))
+    }
+}


### PR DESCRIPTION
Add [`quickcheck`](https://crates.io/crates/quickcheck) support for nucleotides. Every time I construct a [`quickcheck`](https://crates.io/crates/quickcheck) test I find myself desperately wishing for this.