### PR TITLE
Default DnaSequence to using Nucleotide.

### DIFF
--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -136,7 +136,7 @@ impl FromStr for ProteinSequence {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
-pub struct DnaSequence<T: NucleotideLike> {
+pub struct DnaSequence<T: NucleotideLike = Nucleotide> {
     dna: Vec<T>,
 }
 


### PR DESCRIPTION
Hopefully this will make the transition to having a generic parameter a little smoother.