### PR TITLE
Revert default type paremter for DnaSequence and add type aliases instead

### DIFF
--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -135,6 +135,9 @@ impl FromStr for ProteinSequence {
     }
 }
 
+pub type DnaSequenceStrict = DnaSequence<Nucleotide>;
+pub type DnaSequenceAmbiguous = DnaSequence<NucleotideAmbiguous>;
+
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
 pub struct DnaSequence<T: NucleotideLike> {
     dna: Vec<T>,

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -136,7 +136,7 @@ impl FromStr for ProteinSequence {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
-pub struct DnaSequence<T: NucleotideLike = Nucleotide> {
+pub struct DnaSequence<T: NucleotideLike> {
     dna: Vec<T>,
 }
 


### PR DESCRIPTION
This is to avoid accidentally converting code from allowing ambiguous nucleotides to rejecting them.