### PR TITLE
Swooster/additional type inferences

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -14,27 +14,22 @@ where
     fn to_nucleotide_like(self) -> Self::NucleotideType;
 }
 
-impl ToNucleotideLike for Nucleotide {
-    type NucleotideType = Nucleotide;
+impl<N: NucleotideLike> ToNucleotideLike for N {
+    type NucleotideType = N;
 
-    fn to_nucleotide_like(self) -> Nucleotide {
+    fn to_nucleotide_like(self) -> N {
         self
     }
 }
+
+// Sadly, without specialization we can't get this to work with arbitrary
+// &T where T: NucleotideLike but that shouldn't be necessary in practice.
 
 impl ToNucleotideLike for &Nucleotide {
     type NucleotideType = Nucleotide;
 
     fn to_nucleotide_like(self) -> Nucleotide {
         *self
-    }
-}
-
-impl ToNucleotideLike for NucleotideAmbiguous {
-    type NucleotideType = NucleotideAmbiguous;
-
-    fn to_nucleotide_like(self) -> NucleotideAmbiguous {
-        self
     }
 }
 

--- a/src/nucleotide.rs
+++ b/src/nucleotide.rs
@@ -41,7 +41,7 @@ pub enum NucleotideAmbiguous {
 pub trait NucleotideLike:
     Copy + Eq + Into<u8> + Into<char> + TryFrom<u8, Error = TranslationError>
 {
-    type Codon: From<[Self; 3]>;
+    type Codon: From<[Self; 3]> + Into<[Self; 3]>;
 
     fn complement(self) -> Self;
     fn bits(self) -> u8;

--- a/src/trans_table.rs
+++ b/src/trans_table.rs
@@ -159,12 +159,13 @@ impl TranslationTable {
     /// let aas = dna.iter().codons().map(ncbi1);
     /// assert!(aas.eq([b'I', b'D']));
     /// ```
-    pub fn to_fn<C: Into<CodonIdx>>(self) -> impl Copy + Fn(C) -> u8 {
+    pub fn to_fn<N: NucleotideLike, C: Into<[N; 3]>>(self) -> impl Copy + Fn(C) -> u8 {
         let start = self.table_index() * Self::CODONS_PER_TABLE;
         let end = start + Self::CODONS_PER_TABLE;
         let table = &Self::TRANSLATION_TABLES[start..end];
         |codon| {
-            let CodonIdx(i) = codon.into();
+            let nucleotides: [N; 3] = codon.into();
+            let CodonIdx(i) = nucleotides.into();
             table[i]
         }
     }

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,0 +1,36 @@
+use quickdna::{Nucleotide, NucleotideAmbiguous, NucleotideIter, NucleotideLike, TranslationTable};
+
+// The purpose of this is to ensure that it's possible to write code that's
+// generic on NucleotideLike types, without excessive where-clause constraints.
+// In particular:
+// * This only relies on being given a slice of NucleotideLikes
+// * We're able to use NucleotideIter (though it sadly requires .copied())
+// * We're able to map the resulting generic Codons through a translation table.
+fn get_rc_peptide_from_generic_slice(dna: &[impl NucleotideLike]) -> String {
+    let table = TranslationTable::Ncbi1.to_fn();
+    let peptide = dna
+        .iter()
+        .copied()
+        .reverse_complement()
+        .codons()
+        .map(table)
+        .collect();
+    String::from_utf8(peptide).unwrap()
+}
+
+#[test]
+fn test_generic_method() {
+    let dna = {
+        use Nucleotide::*;
+        [C, A, T, T, A, G]
+    };
+    let aas = get_rc_peptide_from_generic_slice(&dna);
+    assert_eq!(aas, "LM");
+
+    let dna_ambiguous = {
+        use NucleotideAmbiguous::*;
+        [C, A, T, T, A, G]
+    };
+    let aas_ambiguous = get_rc_peptide_from_generic_slice(&dna_ambiguous);
+    assert_eq!(aas_ambiguous, "LM");
+}


### PR DESCRIPTION
When writing `NucleotideIter`, I failed to realize that a common use-case was code generic on `NucleotideLike`, so it's only easy-to-use with concrete `NucleotideLike` types. Using it with a generic `NucleotideLike` requires adding a bunch of cumbersome non-obvious constraints, which in turn affects callers of your code. In order to make it convenient to use `NucleotideIter` in generic contexts I'm adding the ability to make the following inferences:
* Anything `NucleotideLike` is `ToNucleotideLike` (sadly, I can't also do this for `&impl NucleotideLike` types generically without specialization, but that's not a big deal in practice because we can work around it with `.copied()` iters)
* Any codons derived from `NucleotideLike` types may be passed to `TranslationTable::to_fn` callables.