### PR TITLE
explicitly prevent publishing in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "quickdna"
 version = "0.3.0"
 edition = "2021"
 authors = ["Theia Vogel <theia@vgel.me>"]
+publish = false
 
 [dependencies]
 lazy_static = "1.4.0"


### PR DESCRIPTION
We don't want to publish yet; say so explicitly in `Cargo.toml` (this will also help in case we use automated release tools like `cargo-release`)

```
quickdna on  chore/no-publish [+1] > cargo publish --dry-run
error: `quickdna` cannot be published.
`package.publish` is set to `false` or an empty list in Cargo.toml and prevents publishing.
```