### PR TITLE
Remove FastaParseSettings::strict() and ::lax()

### DIFF
--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -1332,22 +1332,5 @@ mod tests {
         }
     }
 
-    #[test]
-    fn test_preceding_comment() {
-        let parser = FastaParser::<DnaSequence<Nucleotide>>::new(
-            FastaParseSettings::new().allow_preceding_comment(true),
-        );
-        assert_parse!("AAA", parser, vec![]);
-        assert_parse!(
-            "AAA\n>Virus1\nCCC",
-            parser,
-            vec![FastaRecord {
-                header: "Virus1".to_string(),
-                contents: "CCC".parse().unwrap(),
-                line_range: (2, 4),
-            }]
-        );
-    }
-
     // TODO: when we add validation for ProteinSequence, add tests for that here
 }

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -1299,5 +1299,33 @@ mod tests {
         }
     }
 
+    #[test]
+    fn test_fasta_file_into_iter() {
+        let parser = FastaParser::<DnaSequence<Nucleotide>>::lax();
+        let string = ">Virus1\nCAT\n>Virus2\nTAG";
+
+        // Existing code assumes we can loop over the result of of parse_str... let's explicitly do that.
+        let mut output = vec![];
+        for data in parser.parse_str(string).unwrap() {
+            output.push(data);
+        }
+
+        assert_eq!(
+            output,
+            [
+                FastaRecord {
+                    header: "Virus1".to_owned(),
+                    contents: "CAT".parse().unwrap(),
+                    line_range: (1, 3)
+                },
+                FastaRecord {
+                    header: "Virus2".to_owned(),
+                    contents: "TAG".parse().unwrap(),
+                    line_range: (3, 5)
+                }
+            ]
+        );
+    }
+
     // TODO: when we add validation for ProteinSequence, add tests for that here
 }

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -1296,9 +1296,8 @@ mod tests {
 
     #[test]
     fn test_duplicate_header_lines() {
-        assert_parse!(
+        assert_parse_with_all_settings(
             ">Virus1\nAAAA\nAAAA\n>Virus1\nCCCC\nCCCC\n",
-            FastaParser::<DnaSequence<Nucleotide>>::default(),
             vec![
                 FastaRecord {
                     header: "Virus1".to_string(),
@@ -1310,7 +1309,7 @@ mod tests {
                     contents: "CCCCCCCC".parse().unwrap(),
                     line_range: (4, 7),
                 },
-            ]
+            ],
         );
     }
 

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -59,6 +59,15 @@ impl<T: Display> Display for FastaFile<T> {
     }
 }
 
+impl<T> IntoIterator for FastaFile<T> {
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+    type Item = FastaRecord<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.records.into_iter()
+    }
+}
+
 /// Settings for a fasta parser.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct FastaParseSettings {
@@ -1301,7 +1310,7 @@ mod tests {
 
     #[test]
     fn test_fasta_file_into_iter() {
-        let parser = FastaParser::<DnaSequence<Nucleotide>>::lax();
+        let parser = FastaParser::<DnaSequence<Nucleotide>>::default();
         let string = ">Virus1\nCAT\n>Virus2\nTAG";
 
         // Existing code assumes we can loop over the result of of parse_str... let's explicitly do that.

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -491,38 +491,18 @@ mod tests {
 
     /// Assert a parse matches the expected value with any combination of parser settings
     fn assert_parse_with_all_settings(s: &str, expected: Vec<FastaRecord<String>>) {
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers: true,
-                allow_preceding_comment: true
-            }),
-            expected
-        );
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers: true,
-                allow_preceding_comment: false
-            }),
-            expected
-        );
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers: false,
-                allow_preceding_comment: true
-            }),
-            expected
-        );
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers: false,
-                allow_preceding_comment: false
-            }),
-            expected
-        );
+        for concatenate_headers in [false, true] {
+            for allow_preceding_comment in [false, true] {
+                assert_parse!(
+                    s,
+                    FastaParser::<String>::new(FastaParseSettings {
+                        concatenate_headers,
+                        allow_preceding_comment,
+                    }),
+                    expected
+                );
+            }
+        }
     }
 
     /// Assert a parse matches the expected value with the given value of concatenate_headers,
@@ -532,22 +512,16 @@ mod tests {
         concatenate_headers: bool,
         expected: Vec<FastaRecord<String>>,
     ) {
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers,
-                allow_preceding_comment: true
-            }),
-            expected
-        );
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers,
-                allow_preceding_comment: false
-            }),
-            expected
-        );
+        for allow_preceding_comment in [false, true] {
+            assert_parse!(
+                s,
+                FastaParser::<String>::new(FastaParseSettings {
+                    concatenate_headers,
+                    allow_preceding_comment,
+                }),
+                expected
+            );
+        }
     }
 
     /// Assert a parse matches the expected value with the given value of allow_preceding_comment,
@@ -557,22 +531,16 @@ mod tests {
         allow_preceding_comment: bool,
         expected: Vec<FastaRecord<String>>,
     ) {
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers: true,
-                allow_preceding_comment
-            }),
-            expected
-        );
-        assert_parse!(
-            s,
-            FastaParser::<String>::new(FastaParseSettings {
-                concatenate_headers: false,
-                allow_preceding_comment
-            }),
-            expected
-        );
+        for concatenate_headers in [false, true] {
+            assert_parse!(
+                s,
+                FastaParser::<String>::new(FastaParseSettings {
+                    concatenate_headers,
+                    allow_preceding_comment,
+                }),
+                expected
+            );
+        }
     }
 
     /// Helper to panic if a closure doesn't complete within a specified Duration.

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -412,11 +412,6 @@ impl<T: FromStr> FastaParser<T> {
         }
     }
 
-    /// Construct a new FastaParser with default settings (see [`FastaParseSettings::new()`])
-    pub fn default() -> Self {
-        Self::new(FastaParseSettings::new())
-    }
-
     pub fn parse<R: BufRead>(&self, handle: R) -> Result<FastaFile<T>, FastaParseError<T::Err>> {
         let mut records: Vec<FastaRecord<T>> = vec![];
         let mut state = ParserState::StartOfFile {
@@ -444,6 +439,13 @@ impl<T: FromStr> FastaParser<T> {
 
     pub fn parse_str(&self, s: &str) -> Result<FastaFile<T>, FastaParseError<T::Err>> {
         self.parse(s.as_bytes())
+    }
+}
+
+impl<T: FromStr> Default for FastaParser<T> {
+    /// Construct a new FastaParser with default settings (see [`FastaParseSettings::new()`])
+    fn default() -> Self {
+        Self::new(FastaParseSettings::default())
     }
 }
 
@@ -1347,22 +1349,5 @@ mod tests {
         );
     }
 
-
-    #[test]
-    fn test_preceding_comment() {
-        let parser = FastaParser::<DnaSequence<Nucleotide>>::new(
-            FastaParseSettings::new().allow_preceding_comment(true),
-        );
-        assert_parse!("AAA", parser, vec![]);
-        assert_parse!(
-            "AAA\n>Virus1\nCCC",
-            parser,
-            vec![FastaRecord {
-                header: "Virus1".to_string(),
-                contents: "CCC".parse().unwrap(),
-                line_range: (2, 4),
-            }]
-        );
-    }
     // TODO: when we add validation for ProteinSequence, add tests for that here
 }


### PR DESCRIPTION
…so that we can unambiguously use "strict" and "lax" to instead refer to whether we allow `N` nucleotides or not.

Instead, there is now a `::default()` which _disallows_ preceding file comments (i.e. treats them as sequences), but _does_ concatenate headers. This is the parsing behavior we describe in our internal wiki. Any override of these defaults should be done explicitly when constructing the parser.