### PR TITLE
chore: Release quickdna version 0.4.0

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
   linux-wheels:
     runs-on: ubuntu-latest
-    container: quay.io/pypa/manylinux2010_x86_64
+    container: quay.io/pypa/manylinux2014_x86_64
     steps:
      - uses: actions/checkout@v1
      - name: Build wheels

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickdna"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Theia Vogel <theia@vgel.me>"]
 publish = false


### PR DESCRIPTION
Looked into also adding automatic changelog generation, but we need to format our commits so they can be parsed.

`cargo-release` also did more in the past (it created a `dev-version` after the released version: v0.5.0-alpha after v0.4.0), but looks like now it's just the version bump + git tag.