### PR TITLE
chore: Release quickdna version 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "quickdna"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Theia Vogel <theia@vgel.me>"]
 publish = false


### PR DESCRIPTION
Includes #33, #35 and #36. No Python changes.