### PR TITLE
Add line numbers to parse errors

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -3,6 +3,15 @@ use std::array::TryFromSliceError;
 use thiserror::Error;
 
 #[derive(Debug, Clone, Error)]
+#[error("on line {line_number}: {error}")]
+pub struct Located<E> {
+    pub line_number: usize,
+
+    #[source]
+    pub error: E,
+}
+
+#[derive(Debug, Clone, Error)]
 pub enum TranslationError {
     #[error("non-ascii byte: {:x?}", .0)]
     NonAsciiByte(u8),

--- a/src/extendable.rs
+++ b/src/extendable.rs
@@ -1,0 +1,23 @@
+/// A trait used by the FASTA parser: `T: Extendable` is the type of the
+/// contents of the FASTA file (String or DnaSequence or ProteinSequence).
+/// This trait lets us generically concatenate parsed content lines.
+pub trait Extendable {
+    fn empty() -> Self;
+    fn is_empty(&self) -> bool;
+    fn extend(&mut self, other: Self) -> ();
+}
+
+impl Extendable for String {
+    fn empty() -> Self {
+        "".to_string()
+    }
+
+    /// When parsing a FASTA file, we consider whitespace-only lines to be "empty".
+    fn is_empty(&self) -> bool {
+        self.trim().is_empty()
+    }
+
+    fn extend(&mut self, other: Self) -> () {
+        self.push_str(&other)
+    }
+}

--- a/src/extendable.rs
+++ b/src/extendable.rs
@@ -4,7 +4,7 @@
 pub trait Extendable {
     fn empty() -> Self;
     fn is_empty(&self) -> bool;
-    fn extend(&mut self, other: Self) -> ();
+    fn extend(&mut self, other: Self);
 }
 
 impl Extendable for String {
@@ -17,7 +17,7 @@ impl Extendable for String {
         self.trim().is_empty()
     }
 
-    fn extend(&mut self, other: Self) -> () {
+    fn extend(&mut self, other: Self) {
         self.push_str(&other)
     }
 }

--- a/src/extendable.rs
+++ b/src/extendable.rs
@@ -1,19 +1,16 @@
 /// A trait used by the FASTA parser: `T: Extendable` is the type of the
 /// contents of the FASTA file (String or DnaSequence or ProteinSequence).
 /// This trait lets us generically concatenate parsed content lines.
-pub trait Extendable {
-    fn empty() -> Self;
-    fn is_empty(&self) -> bool;
+pub trait Extendable: Default {
+    /// Is this value empty when ignoring whitespace?
+    fn is_blank(&self) -> bool;
+
+    /// Extend this value by another value.
     fn extend(&mut self, other: Self);
 }
 
 impl Extendable for String {
-    fn empty() -> Self {
-        "".to_string()
-    }
-
-    /// When parsing a FASTA file, we consider whitespace-only lines to be "empty".
-    fn is_empty(&self) -> bool {
+    fn is_blank(&self) -> bool {
         self.trim().is_empty()
     }
 

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -217,6 +217,11 @@ enum ParserState<T: FastaContent> {
     },
 }
 
+type ParseLineResult<T> = Result<
+    (ParserState<T>, Option<FastaRecord<T>>),
+    Located<FastaParseError<<T as FastaContent>::Err>>,
+>;
+
 impl<T: FastaContent> ParserState<T> {
     /// Pump the state machine and maybe emit a record, if this line completes a record, along with
     /// a new state
@@ -225,7 +230,7 @@ impl<T: FastaContent> ParserState<T> {
         settings: &FastaParseSettings,
         line: &str,
         line_number: usize,
-    ) -> Result<(Self, Option<FastaRecord<T>>), Located<FastaParseError<T::Err>>> {
+    ) -> ParseLineResult<T> {
         let new_header = try_parse_header(line);
         let (new_state, record) = match (self, new_header) {
             // start of file, and we have a header line => start a new record,

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -238,7 +238,7 @@ impl<T: FastaContent> ParserState<T> {
             // on parse settings
             (ParserState::StartOfFile { contents }, Some(new_header)) => {
                 // don't emit if the settings don't want it, or if the record would just be whitespace
-                let record = if settings.allow_preceding_comment || contents.is_empty() {
+                let record = if settings.allow_preceding_comment || contents.is_blank() {
                     None
                 } else {
                     Some(FastaRecord {
@@ -293,7 +293,7 @@ impl<T: FastaContent> ParserState<T> {
                         },
                         Some(FastaRecord {
                             header,
-                            contents: T::empty(),
+                            contents: T::default(),
                             line_range: (start_line_number, line_number),
                         }),
                     )
@@ -376,7 +376,7 @@ impl<T: FastaContent> ParserState<T> {
             // start of file => maybe emit contents as a headerless record, depending on settings
             ParserState::StartOfFile { contents } => {
                 // again, don't emit if settings don't want it or the record would just be whitespace
-                if settings.allow_preceding_comment || contents.is_empty() {
+                if settings.allow_preceding_comment || contents.is_blank() {
                     None
                 } else {
                     Some(FastaRecord {
@@ -393,7 +393,7 @@ impl<T: FastaContent> ParserState<T> {
                 header,
             } => Some(FastaRecord {
                 header,
-                contents: T::empty(),
+                contents: T::default(),
                 line_range: (start_line_number, eof_line_number),
             }),
 
@@ -439,7 +439,7 @@ impl<T: FastaContent> FastaParser<T> {
     ) -> Result<FastaFile<T>, Located<FastaParseError<T::Err>>> {
         let mut records: Vec<FastaRecord<T>> = vec![];
         let mut state = ParserState::StartOfFile {
-            contents: T::empty(),
+            contents: T::default(),
         };
 
         let mut line_number = 0;

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -44,7 +44,7 @@ impl<T: Display> Display for FastaRecord<T> {
 impl<T: Display> Display for FastaFile<T> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         for record in &self.records {
-            write!(f, "{}", record)?;
+            write!(f, "{record}")?;
         }
         Ok(())
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ mod errors;
 mod nucleotide;
 pub mod trans_table; // needs to be public for bin/gen_table
 
+mod extendable;
+pub use extendable::*;
+
 mod fasta;
 pub use fasta::*;
 

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -69,17 +69,9 @@ macro_rules! impls {
     };
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
+#[derive(Debug, Default, Clone, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
 pub struct ProteinSequence {
     amino_acids: Vec<u8>,
-}
-
-impl Default for ProteinSequence {
-    fn default() -> Self {
-        ProteinSequence {
-            amino_acids: vec![],
-        }
-    }
 }
 
 impl Extendable for ProteinSequence {

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -74,14 +74,16 @@ pub struct ProteinSequence {
     amino_acids: Vec<u8>,
 }
 
-impl Extendable for ProteinSequence {
-    fn empty() -> Self {
+impl Default for ProteinSequence {
+    fn default() -> Self {
         ProteinSequence {
             amino_acids: vec![],
         }
     }
+}
 
-    fn is_empty(&self) -> bool {
+impl Extendable for ProteinSequence {
+    fn is_blank(&self) -> bool {
         self.amino_acids.is_empty()
     }
 
@@ -169,12 +171,14 @@ pub struct DnaSequence<T: NucleotideLike> {
     dna: Vec<T>,
 }
 
-impl<N: NucleotideLike> Extendable for DnaSequence<N> {
-    fn empty() -> Self {
+impl<N: NucleotideLike> Default for DnaSequence<N> {
+    fn default() -> Self {
         DnaSequence { dna: vec![] }
     }
+}
 
-    fn is_empty(&self) -> bool {
+impl<N: NucleotideLike> Extendable for DnaSequence<N> {
+    fn is_blank(&self) -> bool {
         self.dna.is_empty()
     }
 

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -4,12 +4,12 @@ use std::str::FromStr;
 
 use smallvec::SmallVec;
 
-use crate::Extendable;
 pub use crate::errors::TranslationError;
 pub use crate::nucleotide::{
     Codon, CodonAmbiguous, Nucleotide, NucleotideAmbiguous, NucleotideLike,
 };
 pub use crate::trans_table::TranslationTable;
+use crate::Extendable;
 
 use crate::trans_table::reverse_complement;
 
@@ -76,14 +76,16 @@ pub struct ProteinSequence {
 
 impl Extendable for ProteinSequence {
     fn empty() -> Self {
-        ProteinSequence { amino_acids: vec![] }
+        ProteinSequence {
+            amino_acids: vec![],
+        }
     }
 
     fn is_empty(&self) -> bool {
         self.amino_acids.is_empty()
     }
 
-    fn extend(&mut self, other: Self) -> () {
+    fn extend(&mut self, other: Self) {
         self.amino_acids.extend_from_slice(&other.amino_acids)
     }
 }
@@ -176,7 +178,7 @@ impl<N: NucleotideLike> Extendable for DnaSequence<N> {
         self.dna.is_empty()
     }
 
-    fn extend(&mut self, other: Self) -> () {
+    fn extend(&mut self, other: Self) {
         self.dna.extend_from_slice(&other.dna)
     }
 }

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -4,6 +4,7 @@ use std::str::FromStr;
 
 use smallvec::SmallVec;
 
+use crate::Extendable;
 pub use crate::errors::TranslationError;
 pub use crate::nucleotide::{
     Codon, CodonAmbiguous, Nucleotide, NucleotideAmbiguous, NucleotideLike,
@@ -71,6 +72,20 @@ macro_rules! impls {
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
 pub struct ProteinSequence {
     amino_acids: Vec<u8>,
+}
+
+impl Extendable for ProteinSequence {
+    fn empty() -> Self {
+        ProteinSequence { amino_acids: vec![] }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.amino_acids.is_empty()
+    }
+
+    fn extend(&mut self, other: Self) -> () {
+        self.amino_acids.extend_from_slice(&other.amino_acids)
+    }
 }
 
 #[cfg(feature = "serde")]
@@ -150,6 +165,20 @@ pub type DnaSequenceAmbiguous = DnaSequence<NucleotideAmbiguous>;
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, std::hash::Hash)]
 pub struct DnaSequence<T: NucleotideLike> {
     dna: Vec<T>,
+}
+
+impl<N: NucleotideLike> Extendable for DnaSequence<N> {
+    fn empty() -> Self {
+        DnaSequence { dna: vec![] }
+    }
+
+    fn is_empty(&self) -> bool {
+        self.dna.is_empty()
+    }
+
+    fn extend(&mut self, other: Self) -> () {
+        self.dna.extend_from_slice(&other.dna)
+    }
 }
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
Now quickdna can report errors like `on line 3: error parsing record: bad nucleotide: 'x'`.

I had to change a bit of parser logic to achieve this. Previously, a FASTA record like
```
>Virus1
AAA
CCCx
GGG
```

was first concatenated into one big contents string `"AAACCCxGGG"` which is then `parse()`d as a DNA sequence. But this destroys information about what line an error occurs on.

Now I parse line-by-line, concatenating parsed results (see `Extendable` trait) and exiting early on parse errors.