### PR TITLE
Expose Locate type

### DIFF
--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -9,7 +9,7 @@ use thiserror::Error;
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::errors::Located;
+pub use crate::errors::Located;
 use crate::Extendable;
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,8 @@
 extern crate core;
 
 mod errors;
+pub use errors::*;
+
 mod nucleotide;
 pub mod trans_table; // needs to be public for bin/gen_table
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 extern crate core;
 
 mod errors;
-pub use errors::*;
-
 mod nucleotide;
 pub mod trans_table; // needs to be public for bin/gen_table
 


### PR DESCRIPTION
The FASTA parsing API returns `Locate<T>` errors, but this type is buried in a private module `errors` and not exposed — so consumers can't refer to it, which is a problem.