### PR TITLE
Add conversions to Expansion

### DIFF
--- a/src/expansions.rs
+++ b/src/expansions.rs
@@ -133,6 +133,24 @@ impl Expansion {
     }
 }
 
+impl From<DnaSequenceStrict> for Expansion {
+    fn from(dna: DnaSequenceStrict) -> Self {
+        dna.as_slice().into()
+    }
+}
+
+impl From<&[Nucleotide]> for Expansion {
+    fn from(dna: &[Nucleotide]) -> Self {
+        Self(Arc::from(dna))
+    }
+}
+
+impl From<Arc<[Nucleotide]>> for Expansion {
+    fn from(dna: Arc<[Nucleotide]>) -> Self {
+        Self(dna)
+    }
+}
+
 impl From<Expansion> for DnaSequenceStrict {
     fn from(expansion: Expansion) -> Self {
         expansion.to_dna()


### PR DESCRIPTION
# Intent

In DOPRF window iter code, it'd make the code simpler to be able to construct new `Expansion`s from unambiguous DNA. This adds some conversions to help support that kind of use-case.

# Changes

* Add conversions from `DnaSequenceStrict`, `&[Nucleotide]` or `Arc<[Nucleotide]>` to `Expansion`.