### PR TITLE
Improve protein parsing

### DIFF
--- a/src/errors.rs
+++ b/src/errors.rs
@@ -22,6 +22,8 @@ pub enum TranslationError {
     NonAsciiChar(char),
     #[error("bad nucleotide: {:?}", .0)]
     BadNucleotide(char),
+    #[error("bad amino acid: {:?}", .0)]
+    BadAminoAcid(char),
     #[error("unexpected ambiguous nucleotide: {:?}", .0)]
     UnexpectedAmbiguousNucleotide(char),
     #[error("not a ncbi translation table: {}", .0)]

--- a/src/fasta.rs
+++ b/src/fasta.rs
@@ -1340,6 +1340,19 @@ mod tests {
     }
 
     #[test]
+    fn test_protein_invalid_fasta() {
+        // Note the missing newline between records.
+        assert_parse_err!(
+            ">Virus1\nAAAA\nAAAA>Virus2\nCCCC\nCCCC\n",
+            FastaParser::<ProteinSequence>::default(),
+            Located {
+                line_number: 3,
+                error: FastaParseError::ParseError(TranslationError::BadAminoAcid('>'))
+            }
+        );
+    }
+
+    #[test]
     fn test_to_string() {
         let parser = FastaParser::<DnaSequence<Nucleotide>>::default();
         let string = ">Virus1\nAC\nT\n>Empty\n\n>Virus2\n>with many\n>comment lines\nC  AT";

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -133,14 +133,21 @@ impl TryFrom<&[u8]> for ProteinSequence {
     type Error = TranslationError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        if value.is_ascii() {
-            let mut vec = value.to_vec();
-            vec.retain(|c| *c != b' ' && *c != b'\t');
-            vec.make_ascii_uppercase();
-            Ok(Self { amino_acids: vec })
+        let is_bad_aa = |&&c: &&u8| match c {
+            b'*' | b' ' | b'\t' => false,
+            c => !c.is_ascii_alphabetic(),
+        };
+        if let Some(bad_aa) = value.iter().find(is_bad_aa) {
+            if bad_aa.is_ascii() {
+                Err(TranslationError::BadAminoAcid(char::from(*bad_aa)))
+            } else {
+                Err(TranslationError::NonAsciiByte(*bad_aa))
+            }
         } else {
-            let first_non_ascii = *value.iter().find(|b| !b.is_ascii()).unwrap();
-            Err(TranslationError::NonAsciiByte(first_non_ascii))
+            let mut vec = value.to_vec();
+            vec.make_ascii_uppercase();
+            vec.retain(|c| *c != b' ' && *c != b'\t');
+            Ok(Self { amino_acids: vec })
         }
     }
 }

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -133,15 +133,12 @@ impl TryFrom<&[u8]> for ProteinSequence {
     type Error = TranslationError;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
-        let is_bad_aa = |&&c: &&u8| match c {
-            b'*' | b' ' | b'\t' => false,
-            c => !c.is_ascii_alphabetic(),
-        };
-        if let Some(bad_aa) = value.iter().find(is_bad_aa) {
+        let is_seq_char = |c| matches!(c, b'*' | b' ' | b'\t') || c.is_ascii_alphabetic();
+        if let Some(&bad_aa) = value.iter().find(|&&c| !is_seq_char(c)) {
             if bad_aa.is_ascii() {
-                Err(TranslationError::BadAminoAcid(char::from(*bad_aa)))
+                Err(TranslationError::BadAminoAcid(char::from(bad_aa)))
             } else {
-                Err(TranslationError::NonAsciiByte(*bad_aa))
+                Err(TranslationError::NonAsciiByte(bad_aa))
             }
         } else {
             let mut vec = value.to_vec();

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -769,19 +769,21 @@ mod tests {
     }
 
     #[test]
-    fn test_empty_spaces() {
-        // this test will unwrap() if it cannot parse the DNA
-        dna("gcantacctaangtnattag ");
-        dna("  gcantac\tctaangtnattag ");
-        dna(" gca ntac ctaangtnattag \t");
+    fn test_empty_spaces_are_stripped() {
+        let expected = dna("gcantacctaangtnattag");
+        assert_eq!(dna("gcantacctaangtnattag "), expected);
+        assert_eq!(dna("  gcantac\tctaangtnattag "), expected);
+        assert_eq!(dna(" gca ntac ctaangtnattag \t"), expected);
 
-        dna_strict("gcactacctaacgtcattag ");
-        dna_strict("  gcactac\tctaacgtcattag ");
-        dna_strict(" gca ctac ctaacgtcattag \t");
+        let expected = dna_strict("gcactacctaacgtcattag");
+        assert_eq!(dna_strict("gcactacctaacgtcattag "), expected);
+        assert_eq!(dna_strict("  gcactac\tctaacgtcattag "), expected);
+        assert_eq!(dna_strict(" gca ctac ctaacgtcattag \t"), expected);
 
-        protein("angtnattag ");
-        protein(" angtnattag ");
-        protein(" an  gtnattag \t");
+        let expected = protein("angtnattag");
+        assert_eq!(protein("angtnattag "), expected);
+        assert_eq!(protein(" angtnattag "), expected);
+        assert_eq!(protein(" an  gtnattag \t"), expected);
     }
 
     #[test]

--- a/src/rust_api.rs
+++ b/src/rust_api.rs
@@ -135,6 +135,7 @@ impl TryFrom<&[u8]> for ProteinSequence {
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {
         if value.is_ascii() {
             let mut vec = value.to_vec();
+            vec.retain(|c| *c != b' ' && *c != b'\t');
             vec.make_ascii_uppercase();
             Ok(Self { amino_acids: vec })
         } else {


### PR DESCRIPTION
@Ravna ran into an issue where invalid data wasn't caught early, resulting in much head-scratching: Two fastas had been concatenated without a newline between them, but `FastaParser::<ProteinSequence>` didn't catch that. This fixes that, as well as the fact that proteins don't strip out spaces, even though the tests imply that they should.
